### PR TITLE
Expose namespace reload api

### DIFF
--- a/action/ajax.php
+++ b/action/ajax.php
@@ -40,13 +40,26 @@ class action_plugin_filelisting_ajax extends DokuWiki_Action_Plugin {
         global $INPUT;
 
         $ns = $INPUT->str('namespace');
-        $baseNs = $INPUT->int('baseNamespace');
-        //count level at leat one
-        $lvl = substr_count($ns, ':') - substr_count($baseNs, ':') + 1;
+        $baseNs = $INPUT->str('baseNamespace');
+        $lvl = $this->getNumberOfSubnamespaces($ns) - $this->getNumberOfSubnamespaces($baseNs);
 
         $filelisting = $this->loadHelper('filelisting');
 
         echo $filelisting->getFilesRows($ns, $lvl);
+    }
+
+    /**
+     * Calculate the number of subnamespaces, the given namespace is consisting of
+     *
+     * @param string $namespace
+     * @return int
+     */
+    protected function getNumberOfSubnamespaces($namespace) {
+        $cleanedNamespace = trim($namespace, ':');
+        if ($cleanedNamespace === '') {
+            return 0;
+        }
+        return substr_count($cleanedNamespace, ':') + 1;
     }
 
 }

--- a/action/ajax.php
+++ b/action/ajax.php
@@ -45,7 +45,7 @@ class action_plugin_filelisting_ajax extends DokuWiki_Action_Plugin {
 
         $filelisting = $this->loadHelper('filelisting');
 
-        echo $filelisting->getFilesRows($ns, $lvl);
+        echo $filelisting->getFilesRows($ns, $lvl, $INPUT->bool('filesOnly'));
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -71,13 +71,17 @@ class helper_plugin_filelisting extends DokuWiki_Plugin {
      * Return namespace files as html table rows
      * @param string    $ns
      * @param int       $lvl
+     * @param bool      $filesOnly if true, then the directories in a namespace are ignored
      * @return string
      */
-    public function getFilesRows($ns, $lvl=0) {
+    public function getFilesRows($ns, $lvl=0, $filesOnly = false) {
         $files = $this->getFiles($ns);
         $ret = '';
         foreach ($files as $file) {
             if ($file['isdir']) {
+                if ($filesOnly) {
+                    continue;
+                }
                 $ret .= '<tr data-namespace="'.$file['id'].'"';
             } else {
                 $ret .= '<tr';

--- a/helper.php
+++ b/helper.php
@@ -78,10 +78,10 @@ class helper_plugin_filelisting extends DokuWiki_Plugin {
         $files = $this->getFiles($ns);
         $ret = '';
         foreach ($files as $file) {
+            //skip dirs
+            if ($filesOnly && $file['isdir']) continue;
+
             if ($file['isdir']) {
-                if ($filesOnly) {
-                    continue;
-                }
                 $ret .= '<tr data-namespace="'.$file['id'].'"';
             } else {
                 $ret .= '<tr';


### PR DESCRIPTION
To supplement Drag'n'Drop functionality for file-upload (which is implemented by the dropfiles plugin), it is necessary that we can update the files shown in a namespace.

This pull request provides that functionality. In this case, the exposed API is the event listener for the custom event `namespaceFilesChanged` on .`.plugin__filelisting_content`.