### PR TITLE
jquery objects are always truthy

### DIFF
--- a/script.js
+++ b/script.js
@@ -144,7 +144,7 @@
             $.post(DOKU_BASE + 'lib/exe/ajax.php', data,
                 $.proxy(function(html) {
                     var fileRows = jQuery(html);
-                    if ($row && !$row.data('isExpanded')) {
+                    if ($row.length && !$row.data('isExpanded')) {
                         fileRows.hide();
                     }
                     var $filesInNamespace = $('tr[data-childOf="'+namespace+'"]').not('[data-namespace]');


### PR DESCRIPTION
This fixes a small bug in the API that handles dropped files.

If a new file was dropped onto the files in the current namespace they would all disappear, because a jQuery object is always truthy even if it doesn't contain any elements.