### PR TITLE
keep the table header always visible

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -30,7 +30,7 @@ class helper_plugin_filelisting extends DokuWiki_Plugin {
         }
 
         $colgroup = '<colgroup>';
-        $colgroup .= '<col style="width: 16px;">';
+        $colgroup .= '<col style="width: 25px;">';
         $colgroup .= '<col style="width: 50%;">';
         $colgroup .= '<col style="width: 15%;">';
         $colgroup .= '<col style="width: 35%;">';
@@ -46,6 +46,7 @@ class helper_plugin_filelisting extends DokuWiki_Plugin {
         $ret .= '<div class="plugin__filelisting_collapsible">';
         $ret .= '<div class="plugin__filelisting_content">';
 
+        $ret .= '<div class="plugin__filelisting_headertable">';
         $ret .= '<table>';
         $ret .= $colgroup;
         $ret .= '<thead>';
@@ -57,8 +58,10 @@ class helper_plugin_filelisting extends DokuWiki_Plugin {
         $ret .= '</tr>';
         $ret .= '</thead>';
         $ret .= '</table>';
+        $ret .= '</div>';
 
-        $ret .= '<table class="plugin__filelisting_bodytable">';
+        $ret .= '<div class="plugin__filelisting_bodytable">';
+        $ret .= '<table>';
         $ret .= $colgroup;
         $ret .= '<thead>';
         $ret .= '<tbody>';
@@ -66,6 +69,7 @@ class helper_plugin_filelisting extends DokuWiki_Plugin {
         $ret .= '</tbody>';
 
         $ret .= '</table>';
+        $ret .= '</div>';
         $ret .= '</div>';
 
         //collapsible

--- a/helper.php
+++ b/helper.php
@@ -29,6 +29,13 @@ class helper_plugin_filelisting extends DokuWiki_Plugin {
             $ns_string = $ns;
         }
 
+        $colgroup = '<colgroup>';
+        $colgroup .= '<col style="width: 16px;">';
+        $colgroup .= '<col style="width: 50%;">';
+        $colgroup .= '<col style="width: 15%;">';
+        $colgroup .= '<col style="width: 35%;">';
+        $colgroup .= '</colgroup>';
+
         $ret = '<div class="plugin__filelisting">';
 
         $ret .= '<div class="plugin__filelisting_capiton">';
@@ -38,8 +45,9 @@ class helper_plugin_filelisting extends DokuWiki_Plugin {
         //collapsible is for filter box (added dynamicly by JS)
         $ret .= '<div class="plugin__filelisting_collapsible">';
         $ret .= '<div class="plugin__filelisting_content">';
-        $ret .= '<table>';
 
+        $ret .= '<table>';
+        $ret .= $colgroup;
         $ret .= '<thead>';
         $ret .= '<tr>';
         $ret .= '<th></th>';
@@ -48,7 +56,11 @@ class helper_plugin_filelisting extends DokuWiki_Plugin {
         $ret .= '<th>' . $this->getLang('header filedate') .'</th>';
         $ret .= '</tr>';
         $ret .= '</thead>';
+        $ret .= '</table>';
 
+        $ret .= '<table class="plugin__filelisting_bodytable">';
+        $ret .= $colgroup;
+        $ret .= '<thead>';
         $ret .= '<tbody>';
         $ret .= $this->getFilesRows($ns);
         $ret .= '</tbody>';

--- a/script.js
+++ b/script.js
@@ -369,4 +369,18 @@ jQuery(function() {
     options.filterLabel = LANG.plugins.filelisting.filter_label;
 
     jQuery('.plugin__filelisting').dokuwiki_plugin_filelisting(options);
+
+    /**
+     * Fixes the tablewidths so that the table columns in header and body are exactly aligned
+     *
+     * This is necessary, because browsers have different widths for scrollbars
+     */
+    jQuery('.plugin__filelisting').each(function adjustTableWidthForScrollbar(index, container) {
+        var $bodyTable = jQuery(container).find('.plugin__filelisting_bodytable table');
+        var $headerWrapper = jQuery(container).find('.plugin__filelisting_headertable');
+        var tablediff = $bodyTable.width() - $headerWrapper.find('table').width();
+        var originalPaddingRight = parseInt($headerWrapper.css('padding-right'), 10);
+        var newPaddingRight = originalPaddingRight - tablediff;
+        $headerWrapper.css('padding-right', newPaddingRight + 'px');
+    });
 });

--- a/style.less
+++ b/style.less
@@ -14,16 +14,20 @@
 
     .plugin__filelisting_content {
 
+        .plugin__filelisting_headertable {
+            padding-right: 15px;
+        }
+        .plugin__filelisting_bodytable {
+            display: block;
+            max-height: 200px;
+            overflow-y: scroll;
+        }
+
         table {
             width: 100%;
             //reset default dokuwiki margin
             margin: 0;
-
-            &.plugin__filelisting_bodytable {
-                display: block;
-                max-height: 200px;
-                overflow-y: auto;
-            }
+            table-layout: fixed;
 
             //icon cells
             tr td:first-child {

--- a/style.less
+++ b/style.less
@@ -13,13 +13,17 @@
     }
 
     .plugin__filelisting_content {
-        max-height: 200px;
-        overflow: auto;
 
         table {
             width: 100%;
             //reset default dokuwiki margin
             margin: 0;
+
+            &.plugin__filelisting_bodytable {
+                display: block;
+                max-height: 200px;
+                overflow-y: auto;
+            }
 
             //icon cells
             tr td:first-child {


### PR DESCRIPTION
When scrolling through many files, it would be helpful to keep the table-header visible, so the columns can still be sorted.