### PR TITLE
small improvements for showing and hiding the listing

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,7 +36,7 @@
             .css({
                 float: 'right',
                 cursor: 'pointer'
-            }).appendTo(this.$capiton);
+            }).addClass('plugin__filelisting_toggle').appendTo(this.$capiton);
 
         //by default filelisting is visible
         if (this.getToggleStatus() === 'hidden') {

--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@
 
     Filelisting.prototype.getToggleStatus = function () {
         if (!localStorage.getItem(this.storageKey)) {
-            localStorage.setItem(this.storageKey, this.options.defaultToggle);
+            return this.options.defaultToggle;
         }
         return localStorage.getItem(this.storageKey);
     };


### PR DESCRIPTION
This pull request implements two things:

1. The state is only stored if it is changed. As a result a change in the config option `defaulttoggle` takes effect on all pages where the listing has never been toggled and not only on those pages that have never been visited by the browser before
1. A class is added to the small button which hides/shows the collapsible part of the filelisting, so it can be toggled easier and more robust by other javascript