### PR TITLE
Fix problem with file sorting and filtering

### DIFF
--- a/script.js
+++ b/script.js
@@ -396,7 +396,13 @@ jQuery(function() {
     options.dirClosedIcon = JSINFO.plugin.filelisting.dirClosedIcon;
     options.loadingIcon = JSINFO.plugin.filelisting.loadingIcon;
 
-    options.baseNamespace = JSINFO.namespace;
+    // if base namespace is not properly set, sorting and filtering wont work
+    var ns = jQuery('.plugin__filelisting').data("namespace");
+    if (ns !== undefined) {
+        options.baseNamespace = ns;
+    } else {
+        options.baseNamespace = JSINFO.namespace;
+    }	
 
     options.filterLabel = LANG.plugins.filelisting.filter_label;
     options.deleteConfirm = LANG.plugins.filelisting.delete_confirm;


### PR DESCRIPTION
When displaying a directory whose namespace doesn't correspond to the page containing the filelisting, filtering and sorting don't work at all because the namespace is not properly set. This is a proposed patch to solve this issue, based on the recently introduced `data-namespace` attribute. It is a relatively simplistic solution as it assumes that only a single instance of filelisting is present on the page.