### PR TITLE
Change max-height of file listing to 60vh

### DIFF
--- a/style.less
+++ b/style.less
@@ -25,7 +25,7 @@
         }
         .plugin__filelisting_bodytable {
             display: block;
-            max-height: 200px;
+            max-height: 60vh;
             overflow-y: scroll;
 
             //checkbox cell


### PR DESCRIPTION
This makes the filelisting frame larger as it is now coupled with the viewport height and not fixed to a specific number of pixels.
It solves #20  (or at least makes it a lot better)